### PR TITLE
Added About page to feature repo contributors

### DIFF
--- a/contestreminder/contestreminder/urls.py
+++ b/contestreminder/contestreminder/urls.py
@@ -17,8 +17,11 @@ from django.contrib import admin
 from django.urls import path, include
 from django.views.generic.base import TemplateView
 
+from users.views import contribute
+
 urlpatterns = [
     path('', TemplateView.as_view(template_name='home.html'), name='home'),
+    path('about/', contribute, name='about'),
     path('admin/', admin.site.urls),
     path('users/', include('users.urls')),
     path('users/', include('django.contrib.auth.urls')),

--- a/contestreminder/templates/about.html
+++ b/contestreminder/templates/about.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block title %}About{% endblock %}
+
+{% block content %}
+	<div class="bg-text">
+		<img class="img" src="{% static 'images/Reminder.gif' %}" height = "110px" alt="Reminder">
+		<h1 style="color:black;">About</h1>
+		<h2>These are our wonderful contributors!</h2>
+		{% for contributor in contributors %}
+			{% if contributor.contributions == 1 %}
+				<a href="{{ contributor.html_url }}" target="_blank" rel="nofollow">
+					<img width="100" height="100" src="{{ contributor.avatar_url }}" title="{{ contributor.login }} contributed {{contributor.contributions}} time!"></img>
+				</a>
+			{% else %}
+				<a href="{{ contributor.html_url }}" target="_blank" rel="nofollow">
+					<img width="100" height="100" src="{{ contributor.avatar_url }}" title="{{ contributor.login }} contributed {{contributor.contributions}} times!"></img>
+				</a>
+			{% endif %}
+		{% endfor %}
+		</br></br>
+		<a class="btn2" href="{% url 'home' %}">Home</a>
+	</div>
+{% endblock %}

--- a/contestreminder/templates/home.html
+++ b/contestreminder/templates/home.html
@@ -9,11 +9,13 @@
 		<h1 style="color:black;">Contest Reminder</h1>
 		{% if user.is_authenticated %}
 			Hi {{ user.email }} </br></br>
-			<a class="btn2"  href="{% url 'logout' %}">Log Out</a>
+			<a class="btn2"  href="{% url 'logout' %}">Log Out</a> </br></br>
+			<a class="btn2"  href="{% url 'about' %}">About</a>
 		{% else %}
 			<p>You are not logged in</p>
 			<a class="btn2" href="{% url 'login' %}">Log In</a> </br>
-			<a class="btn2" href="{% url 'signup' %}">Sign Up</a>
+			<a class="btn2" href="{% url 'signup' %}">Sign Up</a> </br></br>
+			<a class="btn2" href="{% url 'about' %}">About</a>
 		{% endif %}
 
 		</br>

--- a/contestreminder/users/views.py
+++ b/contestreminder/users/views.py
@@ -1,4 +1,5 @@
 from django.shortcuts import render
+import requests
 
 # Create your views here.
 from django.urls import reverse_lazy
@@ -10,3 +11,10 @@ class SignUpView(CreateView):
     form_class = CustomUserCreationForm
     success_url = reverse_lazy('login')
     template_name = 'registration/signup.html'
+
+def contribute(request):
+    contributors = {}
+    url = 'https://api.github.com/repos/codestromer/ContestReminder/contributors'
+    response = requests.get(url)
+    contributors = response.json()
+    return render(request, 'about.html', {'contributors': contributors})


### PR DESCRIPTION
Fixes #5 

Created a new About page that highlights the contributors to this repo.

Each contributor has their profile picture showcased, and clicking on each one takes the user to their respective GitHub profile page. Hovering over each photo also displays the username and the number of times that user has contributed to the repository.